### PR TITLE
Refactor: implement argparse for user input

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "distro",
     "requests",
     "pyyaml",
-    "jsonpointer"
+    "jsonpointer",
 ]
 classifiers = [
     "Programming Language :: Python :: 3.10",
@@ -52,3 +52,9 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E722"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+    "ruff>=0.11.12",
+]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,57 @@
+import unittest
+
+import pytest
+
+from woodwork import config_parser
+from woodwork.config_parser import parse_args
+
+
+class TestCLIArgs(unittest.TestCase):
+    def test_log_default(self):
+        args = parse_args([])
+        self.assertEqual(args.log, "info")
+
+    def test_log_debug(self):
+        args = parse_args(["--log", "debug"])
+        self.assertEqual(args.log, "debug")
+
+    def test_invalid_log_level(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--log", "invalid"])
+
+    def test_target_argument(self):
+        args = parse_args(["--workflow", "add", "--target", "/tmp/foo.yaml"])
+        self.assertEqual(args.workflow, "add")
+        self.assertEqual(args.target, "/tmp/foo.yaml")
+
+    def test_init_argument(self):
+        args = parse_args(["--init", "isolated"])
+        self.assertEqual(args.init, "isolated")
+
+    def test_mode_argument(self):
+        args = parse_args(["--mode", "debug"])
+        self.assertEqual(args.mode, "debug")
+
+    def test_missing_add_workflow_target(self):
+        args = parse_args(["--workflow", "add"])
+
+        with pytest.raises(config_parser.ParseError):
+            config_parser.check_parse_conflicts(args)
+
+    def test_missing_remove_workflow_target(self):
+        args = parse_args(["--workflow", "remove"])
+
+        with pytest.raises(config_parser.ParseError):
+            config_parser.check_parse_conflicts(args)
+
+    def test_missing_find_workflow_target(self):
+        args = parse_args(["--workflow", "find"])
+
+        with pytest.raises(config_parser.ParseError):
+            config_parser.check_parse_conflicts(args)
+
+    def test_valid_add_workflow_target(self):
+        args = parse_args(["--workflow", "add", "--target", "/tmp/foo.yaml"])
+        config_parser.check_parse_conflicts(args)
+        assert args.target == "/tmp/foo.yaml"
+        assert args.workflow == "add"

--- a/woodwork/__main__.py
+++ b/woodwork/__main__.py
@@ -21,6 +21,8 @@ def main() -> None:
     try:
         args = config_parser.parse_args()
         logging.basicConfig(level=args.log.upper())
+        # Confirm that there are no known conflicts in the arguments before doing anything else
+        config_parser.check_parse_conflicts(args)
         # TODO: Create a custom logger that extends the root logger
         # Set a delineator for a new application run in log file
         logging.debug("\n" + "=" * 60 + " NEW LOG RUN " + "=" * 60 + "\n")

--- a/woodwork/__main__.py
+++ b/woodwork/__main__.py
@@ -31,13 +31,7 @@ def main() -> None:
         logging.critical("ParseError: %s", e)
         return
 
-
-
     logging.debug(f"Arguments: {args}")
-
-    if args.workflow != "none" and args.target == "":
-        logging.critical("Workflow: %s - Target argument is required for workflow operations.")
-        raise ValueError("Target argument is required for workflow operations.")
 
     # Set globals based on flags before execution
     match args.mode:

--- a/woodwork/config_parser.py
+++ b/woodwork/config_parser.py
@@ -1,8 +1,11 @@
+from dataclasses import dataclass
 import os
 from dotenv import load_dotenv
 import re
 import inspect
 import json
+import argparse
+from typing import Optional, Sequence
 
 from woodwork.helper_functions import print_debug
 from woodwork.errors import ForbiddenVariableNameError, MissingConfigKeyError
@@ -451,4 +454,91 @@ def find_action_plan(query: str):
                 result = similar_prompts[i]
 
                 print(f"{result['value']} {result['nodeID']}")
+    return
+
+
+def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    """
+    Parse command line arguments to configure Woodwork.
+
+    Args:
+        args (Optional[Sequence[str]], optional): Optional . Defaults to None.
+
+    Returns:
+        argparse.Namespace: The parsed command line arguments as a Namespace object.
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Woodwork CLI for managing and executing workflows.",
+        add_help=True,
+    )
+
+    parser.add_argument(
+        "--log",
+        choices=["debug", "info", "warning", "error", "critical"],
+        default="info",
+        help="Set the logging level for the CLI. (default: info)",
+    )
+
+    parser.add_argument(
+        "--mode",
+        choices=["run", "debug", "embed", "clear"],
+        default="run",
+        help="Set the mode of operation for the CLI. Use 'debug' for debugging purposes. (default: run)",
+    )
+
+    parser.add_argument(
+        "--init",
+        type=str,
+        choices=["none", "isolated", "all"],
+        default="none",
+        help="Initialize Woodwork with options. Use 'isolated' to create an isolated environment, 'all' to initialize all components. (default: none)",
+    )
+
+    parser.add_argument(
+        "--workflow",
+        choices=["none", "add", "remove", "find"],
+        default="none",
+        help="Manage workflows. Use 'add' to add a workflow, 'remove' to remove a workflow, 'find' to search for a workflow. (default: none)",
+    )
+
+    parser.add_argument(
+        "--target",
+        default="",
+        metavar="[File path/Search query/Workflow ID]",
+        help=(
+            "For adding workflows, provide the file path to the workflow. "
+            + "For finding workflows, provide a search query. "
+            + "For removing workflows, provide the workflow ID. (default: empty string)"
+        ),
+    )
+
+    return parser.parse_args(args)
+
+
+@dataclass
+class ParseError(Exception):
+    """
+    Custom exception for handling parsing errors.
+    """
+
+    message: str
+
+
+def check_parse_conflicts(args: argparse.Namespace) -> None:
+    """
+    Check for conflicts in the parsed arguments.
+
+    Args:
+        args (argparse.Namespace): The parsed command line arguments.
+
+    Raises:
+        ParseError: If there are conflicts in the arguments.
+    """
+
+    if args.workflow != "none" and args.target == "":
+        raise ParseError(
+            message="Target argument is required for workflow operations. See --help for more information."
+        )
+
     return


### PR DESCRIPTION
Refactor to utilize argparse to close #149. Include a smattering of tests to ensure the argparse functionality works as expected. Does not test the functionality of the larger app itself, just the argparse and sending the correct arguments to global_config. Add a root logger (which should be customized) and updates the `.toml` file to include dev dependencies for `pytest` and `ruff`. This likely deprecates a number of custom functions, so running some static analysis to find dead code may be beneficial.

I haven't tested full libraries functionality, so you may want to clone this branch to your local env and make sure it works as intended. I essentially "patched" all the actual code functions and just made sure I called the function based on the original condition, or set the global_env dictionary.

That being said, the new pytest tests and ruff checks pass. You may want to look into being explicit about what ruff rules you care about.