### PR TITLE
Added `.pre-commit-config.yaml` and Docs for Testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.11.12
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+      types_or: [ python, pyi ]
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+      types_or: [ python, pyi ]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ When using `woodwork` as a dependency, you will need to build your own logger im
 1. In your file you'd like to utilize `woodwork` in, add `from woodwork import __main__ as m`
 1. See [`dev-main.py`](./dev-main.py) for how to build your logger and configure calling `woodwork`
 
+## Developer Setup
+If you are interested in contributing, the following steps are used to activate a developer environment.
+
+1. Install `pre-commit` if needed via `pip install pre-commit`
+1. Run `pre-commit install [--hook-type pre-push]` to run linting and formatting before commiting or pushing
+
 ## Available Arguments
 
 You can pass arguments to `woodwork`. For more details, see `woodwork --help`.

--- a/dev-main.py
+++ b/dev-main.py
@@ -19,21 +19,22 @@ def create_custom_logger(config_path: str) -> None:
     with open(config_file) as f_in:
         config = json.load(f_in)
 
-    # Get the directory for logging as specified in the logging_config.json file to 
-    # create the log directory if it does not exist. The filename in the config file 
-    # must be only one folder deep from the root, such as "./logs/", however the 
+    # Get the directory for logging as specified in the logging_config.json file to
+    # create the log directory if it does not exist. The filename in the config file
+    # must be only one folder deep from the root, such as "./logs/", however the
     # directory name can be anything.
     log_directory = pathlib.Path(config["handlers"]["file"]["filename"].split("/")[0])
     if not log_directory.exists():
-       log_directory.mkdir()
+        log_directory.mkdir()
 
     logging.config.dictConfig(config)
-    #queue_handler = logging.getHandlerByName("queue_handler")
-    #if queue_handler is not None:
+    # queue_handler = logging.getHandlerByName("queue_handler")
+    # if queue_handler is not None:
     #    queue_handler.handle.listener.start()
     #    atexit.register(queue_handler.handle.listener.stop)
 
     return None
+
 
 if __name__ == "__main__":
     create_custom_logger("./config/log_config.json")

--- a/docs/explanation/test.md
+++ b/docs/explanation/test.md
@@ -1,0 +1,7 @@
+---
+title: Testing
+description: A test markdown file for nested files.
+index: 0
+---
+
+Testing text!

--- a/docs/how-to/test.md
+++ b/docs/how-to/test.md
@@ -1,0 +1,7 @@
+---
+title: Testing
+description: A test markdown file for nested files.
+index: 0
+---
+
+Testing text!

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -1,0 +1,7 @@
+---
+title: Testing
+description: A test markdown file for nested files.
+index: 0
+---
+
+Testing text!

--- a/docs/tutorials/test.md
+++ b/docs/tutorials/test.md
@@ -1,0 +1,7 @@
+---
+title: Testing
+description: A test markdown file for nested files.
+index: 0
+---
+
+Testing text!

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,7 +1,0 @@
----
-title: Workflows
-description: description
-index: 1
----
-
-This is a test!

--- a/tests/dynamic_imports_test.py
+++ b/tests/dynamic_imports_test.py
@@ -10,6 +10,7 @@ def test_venv_setup():
     except:
         assert False
 
+
 @pytest.mark.skip("Skipping...revisit test validity.")
 def test_all_requirements_present():
     activate_virtual_environment()

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -1,4 +1,4 @@
-#from woodwork.dependencies import activate_virtual_environment
+# from woodwork.dependencies import activate_virtual_environment
 from woodwork.config_parser import parse
 from woodwork.errors import ForbiddenVariableNameError
 
@@ -6,9 +6,10 @@ import pytest
 import os
 from dotenv import load_dotenv
 
+
 @pytest.skip("Skipping...revisit test validity.", allow_module_level=True)
 
-#activate_virtual_environment()
+# activate_virtual_environment()
 
 
 # Testing component name declaration
@@ -108,6 +109,7 @@ def test_string_values():
     components = parse(config)
     assert components["name1"]["config"] == {"key1": "value1"}
 
+
 @pytest.mark.skip("Skipping...revisit test validity.")
 def test_variable_values():
     from woodwork.components.llms.openai import openai
@@ -133,6 +135,7 @@ def test_variable_values():
 #     """
 #     components = parse(config)
 #     assert components["name1"]["config"] == {"key1": ["value1", "value2", "value3"]}
+
 
 @pytest.mark.skip("Skipping...revisit test validity.")
 def test_list_variable_values():
@@ -243,6 +246,7 @@ def test_nested_special_values():
         "key3": "value3",
     }
 
+
 @pytest.mark.skip("Skipping...revisit test validity.")
 def test_nested_variable_references():
     from woodwork.components.llms.openai import openai
@@ -262,6 +266,7 @@ def test_nested_variable_references():
     """
     components = parse(config)
     assert isinstance(components["name1"]["config"]["key1"]["subkey1"]["subkey2"], openai)
+
 
 @pytest.mark.skip("Skipping...revisit test validity. Typically don't want to test environment variables in unit tests.")
 def test_environment_values():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,8 +53,6 @@ class TestCLIArgs(unittest.TestCase):
         with pytest.raises(config_parser.ParseError):
             config_parser.check_parse_conflicts(args)
 
-
-
     def test_valid_add_workflow_target(self):
         args = parse_args(["--workflow", "add", "--target", "/tmp/foo.yaml"])
         config_parser.check_parse_conflicts(args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,6 +53,8 @@ class TestCLIArgs(unittest.TestCase):
         with pytest.raises(config_parser.ParseError):
             config_parser.check_parse_conflicts(args)
 
+
+
     def test_valid_add_workflow_target(self):
         args = parse_args(["--workflow", "add", "--target", "/tmp/foo.yaml"])
         config_parser.check_parse_conflicts(args)

--- a/woodwork/components/apis/functions.py
+++ b/woodwork/components/apis/functions.py
@@ -7,6 +7,8 @@ from woodwork.helper_functions import format_kwargs
 from woodwork.components.apis.api import api
 
 log = logging.getLogger(__name__)
+
+
 class functions(api):
     def __init__(self, path: str, **config):
         format_kwargs(config, path=path, type="functions")

--- a/woodwork/components/apis/web.py
+++ b/woodwork/components/apis/web.py
@@ -8,6 +8,7 @@ from woodwork.helper_functions import format_kwargs
 
 log = logging.getLogger(__name__)
 
+
 class web(api):
     def __init__(self, url: str, **config):
         format_kwargs(config, url=url, type="web")

--- a/woodwork/components/decomposers/decomposer.py
+++ b/woodwork/components/decomposers/decomposer.py
@@ -8,6 +8,7 @@ from woodwork.helper_functions import format_kwargs, get_optional
 
 log = logging.getLogger(__name__)
 
+
 class decomposer(component, ABC):
     def __init__(self, tools, output, **config):
         format_kwargs(config, tools=tools, output=output, component="decomposer")

--- a/woodwork/components/decomposers/llm.py
+++ b/woodwork/components/decomposers/llm.py
@@ -9,6 +9,7 @@ from woodwork.helper_functions import format_kwargs
 
 log = logging.getLogger(__name__)
 
+
 class llm(decomposer):
     def __init__(self, api_key: str, **config):
         format_kwargs(config, api_key=api_key, type="llm")

--- a/woodwork/components/llms/llm.py
+++ b/woodwork/components/llms/llm.py
@@ -29,7 +29,7 @@ class llm(component, tool_interface, knowledge_base_interface, ABC):
         # Defining the system prompt
         if self._memory:
             system_prompt = (
-                "You are a helpful assistant, answer the provided question, " "In 3 sentences or less. " "{memory}"
+                "You are a helpful assistant, answer the provided question, In 3 sentences or less. {memory}"
             ).format(memory=short_term_memory)
         else:
             system_prompt = "You are a helpful assistant, answer the provided question, In 3 sentences or less. "

--- a/woodwork/components/task_master.py
+++ b/woodwork/components/task_master.py
@@ -40,7 +40,7 @@ class task_master(component):
 
             # Add the result to the variables
             variables[instruction["output"]] = result
-            prev_instructon = result # TODO: @willwoodward fix spelling of variable if necessary
+            prev_instructon = result  # TODO: @willwoodward fix spelling of variable if necessary
             log.debug(f"instruction = {instruction}")
             log.debug(f"result = {result}")
 

--- a/woodwork/config_parser.py
+++ b/woodwork/config_parser.py
@@ -332,9 +332,7 @@ def parse_config(entry: str) -> dict:
             for i in range(len(value)):
                 depends_on.append(value[i])
 
-        elif (value[0] == '"' and value[-1] == '"') or (
-            value[0] == "'" and value[-1] == "'"
-        ):
+        elif (value[0] == '"' and value[-1] == '"') or (value[0] == "'" and value[-1] == "'"):
             value = value[1:-1:]
 
         # If the value is not a string, it references a variable
@@ -370,14 +368,9 @@ def parse(config: str) -> dict:
         # Replace these with some fancy regex
         command["variable"] = entry.split("=")[0].strip()
         command["component"] = entry.split("=")[1].split(" ")[1].strip()
-        command["type"] = (
-            entry.split("=")[1].split(command["component"])[1].split("{")[0].strip()
-        )
+        command["type"] = entry.split("=")[1].split(command["component"])[1].split("{")[0].strip()
 
-        if (
-            command["variable"].lower() == "true"
-            or command["variable"].lower() == "false"
-        ):
+        if command["variable"].lower() == "true" or command["variable"].lower() == "false":
             raise ForbiddenVariableNameError(
                 "A boolean cannot be used as a variable name.",
                 line_number,

--- a/woodwork/deployments/docker.py
+++ b/woodwork/deployments/docker.py
@@ -22,7 +22,7 @@ class Docker:
         if volume_location is not None:
             self.container_args["volumes"] = {
                 os.path.abspath(self.path): {
-                    "bind": f"/{self.path.split("/")[-1]}",
+                    "bind": f"/{self.path.split('/')[-1]}",
                     "mode": "rw",
                 }
             }

--- a/woodwork/errors.py
+++ b/woodwork/errors.py
@@ -14,19 +14,16 @@ class WoodworkError(Exception):
         # Basic error message
         start_bold = "\033[1m"
         end_bold = "\033[0m"
-        formatted_message = f"{start_bold}{Fore.RED}{self.__class__.__name__}:{end_bold} {self.message}{Style.RESET_ALL}"
+        formatted_message = (
+            f"{start_bold}{Fore.RED}{self.__class__.__name__}:{end_bold} {self.message}{Style.RESET_ALL}"
+        )
 
         # Add line and column details, if available
-        if (
-            self.line is not None
-            and self.line_content is not None
-            and self.column is not None
-        ):
-            indicator = (
-                " " * (self.column - 1 + 7 + len(str(self.line)))
-                + f"{Fore.CYAN}^{Style.RESET_ALL}"
+        if self.line is not None and self.line_content is not None and self.column is not None:
+            indicator = " " * (self.column - 1 + 7 + len(str(self.line))) + f"{Fore.CYAN}^{Style.RESET_ALL}"
+            formatted_message += (
+                f"\nLine {Fore.YELLOW}{self.line}{Style.RESET_ALL}: {self.line_content.strip()}\n{indicator}"
             )
-            formatted_message += f"\nLine {Fore.YELLOW}{self.line}{Style.RESET_ALL}: {self.line_content.strip()}\n{indicator}"
 
         return formatted_message
 

--- a/woodwork/helper_functions.py
+++ b/woodwork/helper_functions.py
@@ -12,8 +12,9 @@ def set_globals(**kwargs) -> None:
     for key, value in kwargs.items():
         config[key] = value
 
+
 # If you ever support >=3.13 at minimum, you can switch this for the built in @deprecated decorator from warnings.
-# This will give you intellisense anytime someone uses the function. @dakotatokad think's they've got all 
+# This will give you intellisense anytime someone uses the function. @dakotatokad think's they've got all
 # usages of this function, but will leave it in as deprecated just in case its called somewhere they didn't find.
 # Ideally, this function should just be removed when all usages are updated to use the logger directly.
 @deprecated(reason="Use log.debug() instead.", category=DeprecationWarning, extra_stacklevel=2)


### PR DESCRIPTION
Added the `.pre-commit-config.yaml` from ruff, running both the linter and formatter. Still need to add static type checking when `ty` is added to the project. Added documentation in the README.md for commands to apply it pre-commit or pre-push.

Also added testing files to sync with the docs repo, just checking that nested folders sync across to woodwork-website. Will work on implementing nested subfolders there, with the hopes of providing a better docs setup and the goal of producing more introductory docs in the next day or two.