### PR TITLE
feat: add version information flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
+# woodwork-engine
+
 [![PyPI - Version](https://img.shields.io/pypi/v/woodwork-engine.svg?logo=pypi&label=PyPI&logoColor=gold)](https://pypi.org/project/woodwork-engine/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/woodwork-engine.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/woodwork-engine/)
 [![PyPI - Installs](https://img.shields.io/pypi/dm/woodwork-engine.svg?color=blue&label=Installs&logo=pypi&logoColor=gold)](https://pypi.org/project/woodwork-engine/)
 [![License](https://img.shields.io/github/license/willwoodward/woodwork-engine?label=License&logo=open-source-initiative)](https://github.com/willwoodward/woodwork-engine/blob/main/LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/willwoodward/woodwork-engine?label=Stars&logo=github)](https://github.com/willwoodward/woodwork-engine/stargazers)
 
-# woodwork-engine
 Welcome to woodwork-engine, an AI Agent IaC tool that aims to make developing and deploying AI Agents easier.
 
 Through defining components in a configuration language, an LLM will decompose the task into actionable steps, which can be executed using the supplied tools. We use latest research to inform design decisions, and we implement this as most of the setup is copy/paste across projects. Through only focussing on the necessary components of a system, this package should make designing custom, vertical agents much easier.
 
 ## Table of Contents
+
 - [Features](#features)
 - [Installation](#installation)
 - [Usage](#usage)
@@ -18,6 +20,7 @@ Through defining components in a configuration language, an LLM will decompose t
 - [License](#license)
 
 ## Features
+
 - A custom config language, woodwork (.ww files), allowing agent components to be declared
 - Integrations and communication between components are handled
 - Additional customisation or extension can be provided by implementing some of our interfaces
@@ -27,6 +30,7 @@ Through defining components in a configuration language, an LLM will decompose t
 A [roadmap](https://github.com/willwoodward/woodwork-meta/blob/main/ROADMAP.md) is provided with details on future features.
 
 ## Installation
+
 1. **Run `pip install woodwork-engine`**: This gives access to the `woodwork` CLI tool, along with the ability to parse and deploy AI Agent components from .ww files
 2. **Install the Woodwork extension on VSCode if relevant**: This provides syntax highlighting and intellisense for code in .ww files
 
@@ -56,6 +60,7 @@ When using `woodwork` as a dependency, you will need to build your own logger im
 1. See [`dev-main.py`](./dev-main.py) for how to build your logger and configure calling `woodwork`
 
 ## Developer Setup
+
 If you are interested in contributing, the following steps are used to activate a developer environment.
 
 1. Install `pre-commit` if needed via `pip install pre-commit`
@@ -71,6 +76,7 @@ You can pass arguments to `woodwork`. For more details, see `woodwork --help`.
 |`--init`|`none`, `isolated`, `all`|`none`||
 |`--workflow`|`none`, `add`, `remove`, `find`|`none`|If specifying a workflow, you must provide a target.|
 |`--target`|String|`""`|Defines the target for the workflow. For add workflows, specify the file path to the workflow. For `remove` workflows, specify the workflow ID. For `find` workflows, specify the search query.|
+|`--version`|N/A|N/A|Prints the current version of Woodwork. Note: this will override any other arguments.|
 
 When calling your script, you can pass argument to the script as long as they do not conflict with `woodworks` arguments.
 
@@ -81,11 +87,13 @@ In `log_config.json`, you can set the desired logging levels for stdout and the 
 You can monitor the log file during execution by opening a terminal and entering `tail -f logs/debug_log.log` (or your custom log file name if modified in the `log_config.json`)
 
 ## Examples
+
 For some examples, consult the examples folder. ENV variables are denotes by a '$', place a .env file in the same directory as the main.ww file and populate it with the necessary variables.
 
 ## Contributing
+
 To view the contributing guide for woodwork, the [CONTRIBUTING.md](https://github.com/willwoodward/woodwork-meta/blob/main/CONTRIBUTING.md) file in the meta repository contains more information. We would love your help! Additionally, if you prefer working on other projects aligned with language servers or web development, [woodwork-language](https://github.com/willwoodward/woodwork-language) and [woodwork-website](https://github.com/willwoodward/woodwork-website) could be worth taking a look at.
 
 ## License
-woodwork-engine uses a GPL license, which can be read in full [here](./LICENSE).
 
+woodwork-engine uses a GPL license, which can be read in full [here](./LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ readme = "README.md"
 authors = [{ name = "Will Woodward" }]
 requires-python = ">=3.10"
 dependencies = [
-    "python-dotenv",
-    "colorama",
-    "idna",
-    "distro",
-    "requests",
-    "pyyaml",
-    "jsonpointer",
-    "deprecated",
+    "colorama>=0.4.6",
+    "deprecated>=1.2.18",
+    "distro>=1.9.0",
+    "idna>=3.10",
+    "jsonpointer>=3.0.0",
+    "python-dotenv>=1.1.0",
+    "pyyaml>=6.0.2",
+    "requests>=2.32.3",
     "tomli>=2.2.1",
 ]
 classifiers = [
@@ -29,13 +29,13 @@ classifiers = [
 
 [project.optional-dependencies]
 all = [
-    "langchain",
-    "chromadb",
-    "langchain_chroma",
-    "langchain_community",
-    "sentence-transformers",
-    "pytest",
-    "ruff",
+    "chromadb>=1.0.12",
+    "langchain>=0.3.25",
+    "langchain-chroma>=0.2.4",
+    "langchain-community>=0.3.24",
+    "pytest>=8.3.5",
+    "ruff>=0.11.12",
+    "sentence-transformers>=4.1.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyyaml",
     "jsonpointer",
     "deprecated",
+    "tomli>=2.2.1",
 ]
 classifiers = [
     "Programming Language :: Python :: 3.10",

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -2,8 +2,8 @@ import unittest
 
 import pytest
 
-from woodwork import config_parser
-from woodwork.config_parser import parse_args
+from woodwork.errors import ParseError
+from woodwork.argument_parser import parse_args, check_parse_conflicts
 
 
 class TestCLIArgs(unittest.TestCase):
@@ -38,23 +38,23 @@ class TestCLIArgs(unittest.TestCase):
     def test_missing_add_workflow_target(self):
         args = parse_args(["--workflow", "add"])
 
-        with pytest.raises(config_parser.ParseError):
-            config_parser.check_parse_conflicts(args)
+        with pytest.raises(ParseError):
+            check_parse_conflicts(args)
 
     def test_missing_remove_workflow_target(self):
         args = parse_args(["--workflow", "remove"])
 
-        with pytest.raises(config_parser.ParseError):
-            config_parser.check_parse_conflicts(args)
+        with pytest.raises(ParseError):
+            check_parse_conflicts(args)
 
     def test_missing_find_workflow_target(self):
         args = parse_args(["--workflow", "find"])
 
-        with pytest.raises(config_parser.ParseError):
-            config_parser.check_parse_conflicts(args)
+        with pytest.raises(ParseError):
+            check_parse_conflicts(args)
 
     def test_valid_add_workflow_target(self):
         args = parse_args(["--workflow", "add", "--target", "/tmp/foo.yaml"])
-        config_parser.check_parse_conflicts(args)
+        check_parse_conflicts(args)
         assert args.target == "/tmp/foo.yaml"
         assert args.workflow == "add"

--- a/woodwork/__main__.py
+++ b/woodwork/__main__.py
@@ -4,8 +4,9 @@ import logging.config
 import pathlib
 import sys
 
-from woodwork import config_parser, dependencies
-from woodwork.errors import WoodworkError
+from woodwork import config_parser, dependencies, argument_parser
+from woodwork import helper_functions
+from woodwork.errors import WoodworkError, ParseError
 from woodwork.helper_functions import set_globals
 
 from . import globals
@@ -28,9 +29,16 @@ def main(args) -> None:
 
     try:
         # Confirm that there are no known conflicts in the arguments before doing anything else
-        config_parser.check_parse_conflicts(args)
-    except config_parser.ParseError as e:
+        argument_parser.check_parse_conflicts(args)
+    except ParseError as e:
         log.critical("ParseError: %s", e)
+        return
+
+    if args.version:
+        version_from_toml = helper_functions.get_version_from_pyproject(
+            str(pathlib.Path(__file__).parent.parent / "pyproject.toml")
+        )
+        print(f"Woodwork version: {version_from_toml}")
         return
 
     log.debug("Arguments: %s", args)
@@ -132,7 +140,7 @@ def run_as_standalone_app() -> None:
     Do not use this function if you have configured your own logger. Simply call `main()` directly.
     """
 
-    args = config_parser.parse_args()
+    args = argument_parser.parse_args()
 
     if args.logConfig is not None:
         # If a custom logging configuration file is specified, use it

--- a/woodwork/argument_parser.py
+++ b/woodwork/argument_parser.py
@@ -1,0 +1,93 @@
+import argparse
+from collections.abc import Sequence
+
+from .errors import ParseError
+
+
+def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
+    """
+    Parse command line arguments to configure Woodwork.
+
+    Args:
+        args (Optional[Sequence[str]], optional): Optional . Defaults to None.
+
+    Returns:
+        argparse.Namespace: The parsed command line arguments as a Namespace object.
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Woodwork CLI for managing and executing workflows.",
+        add_help=True,
+    )
+
+    # TODO: @willwoodward - Remove debug when appropriate in your release cycle.
+    # Currently defaults to run if debug is chosen.
+    parser.add_argument(
+        "--mode",
+        choices=["run", "debug", "embed", "clear"],
+        default="run",
+        help="Set the mode of operation for the CLI. Use 'debug' for debugging purposes. (default: run)",
+    )
+
+    parser.add_argument(
+        "--init",
+        type=str,
+        choices=["none", "isolated", "all"],
+        default="none",
+        help=(
+            "Initialize Woodwork with options. Use 'isolated' to create an isolated environment,"
+            "'all' to initialize all components. (default: none)"
+        ),
+    )
+
+    parser.add_argument(
+        "--workflow",
+        choices=["none", "add", "remove", "find"],
+        default="none",
+        help=(
+            "Manage workflows. Use 'add' to add a workflow, 'remove' to remove a workflow, "
+            "'find' to search for a workflow. (default: none)"
+        ),
+    )
+
+    parser.add_argument(
+        "--target",
+        default="",
+        metavar="[File path/Search query/Workflow ID]",
+        help=(
+            "For adding workflows, provide the file path to the workflow. "
+            + "For finding workflows, provide a search query. "
+            + "For removing workflows, provide the workflow ID. (default: empty string)"
+        ),
+    )
+
+    parser.add_argument(
+        "--logConfig",
+        default=None,
+        help=("A custom path to a JSON logging configuration file."),
+    )
+
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Display the version of Woodwork and exit.",
+    )
+
+    return parser.parse_args(args)
+
+
+def check_parse_conflicts(args: argparse.Namespace) -> None:
+    """
+    Check for conflicts in the parsed arguments.
+
+    Args:
+        args (argparse.Namespace): The parsed command line arguments.
+
+    Raises:
+        ParseError: If there are conflicts in the arguments.
+    """
+
+    if args.workflow != "none" and args.target == "":
+        raise ParseError(
+            message="Target argument is required for workflow operations. See --help for more information.",
+        )

--- a/woodwork/config_parser.py
+++ b/woodwork/config_parser.py
@@ -1,10 +1,8 @@
-import argparse
 import inspect
 import json
 import logging
 import os
 import re
-from collections.abc import Sequence
 
 from dotenv import load_dotenv
 
@@ -12,7 +10,6 @@ from woodwork.components.task_master import task_master
 from woodwork.errors import (
     ForbiddenVariableNameError,
     MissingConfigKeyError,
-    ParseError,
 )
 
 log = logging.getLogger(__name__)
@@ -474,86 +471,3 @@ def find_action_plan(query: str):
                 result = similar_prompts[i]
 
                 print(f"{result['value']} {result['nodeID']}")
-
-
-def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
-    """
-    Parse command line arguments to configure Woodwork.
-
-    Args:
-        args (Optional[Sequence[str]], optional): Optional . Defaults to None.
-
-    Returns:
-        argparse.Namespace: The parsed command line arguments as a Namespace object.
-    """
-
-    parser = argparse.ArgumentParser(
-        description="Woodwork CLI for managing and executing workflows.",
-        add_help=True,
-    )
-
-    # TODO: @willwoodward - Remove debug when appropriate in your release cycle.
-    # Currently defaults to run if debug is chosen.
-    parser.add_argument(
-        "--mode",
-        choices=["run", "debug", "embed", "clear"],
-        default="run",
-        help="Set the mode of operation for the CLI. Use 'debug' for debugging purposes. (default: run)",
-    )
-
-    parser.add_argument(
-        "--init",
-        type=str,
-        choices=["none", "isolated", "all"],
-        default="none",
-        help=(
-            "Initialize Woodwork with options. Use 'isolated' to create an isolated environment,"
-            "'all' to initialize all components. (default: none)"
-        ),
-    )
-
-    parser.add_argument(
-        "--workflow",
-        choices=["none", "add", "remove", "find"],
-        default="none",
-        help=(
-            "Manage workflows. Use 'add' to add a workflow, 'remove' to remove a workflow, "
-            "'find' to search for a workflow. (default: none)"
-        ),
-    )
-
-    parser.add_argument(
-        "--target",
-        default="",
-        metavar="[File path/Search query/Workflow ID]",
-        help=(
-            "For adding workflows, provide the file path to the workflow. "
-            + "For finding workflows, provide a search query. "
-            + "For removing workflows, provide the workflow ID. (default: empty string)"
-        ),
-    )
-
-    parser.add_argument(
-        "--logConfig",
-        default=None,
-        help=("A custom path to a JSON logging configuration file."),
-    )
-
-    return parser.parse_args(args)
-
-
-def check_parse_conflicts(args: argparse.Namespace) -> None:
-    """
-    Check for conflicts in the parsed arguments.
-
-    Args:
-        args (argparse.Namespace): The parsed command line arguments.
-
-    Raises:
-        ParseError: If there are conflicts in the arguments.
-    """
-
-    if args.workflow != "none" and args.target == "":
-        raise ParseError(
-            message="Target argument is required for workflow operations. See --help for more information.",
-        )

--- a/woodwork/helper_functions.py
+++ b/woodwork/helper_functions.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import logging
 from deprecated import deprecated
+import tomli  # tomli since we support P3.10 and tomllib is not available until P3.11
 
 from woodwork.globals import global_config as config
 
@@ -82,3 +83,13 @@ def format_kwargs(kwarg_dict, **kwargs) -> None:
     for kwarg in kwargs:
         kwarg_dict[kwarg] = kwargs[kwarg]
     return
+
+
+def get_version_from_pyproject(pyproject_path="pyproject.toml") -> str:
+    """
+    Get the version from the pyproject.toml file.
+    """
+    with open(pyproject_path, "rb") as f:
+        data = tomli.load(f)
+
+    return data["project"]["version"]


### PR DESCRIPTION
Add a flag that will print the version of Woodwork when running the CLI. It pulls this version from the pyproject.toml file. It will end the program run after printing the version.

Updated readme for new argument.

Moved argument parsing functionality out of config parsing module since they serve different purposes.

Linted the readme.

Fixed tests.

Closes #155 (completely)

```zsh
╰─>> uv run woodwork --version
Woodwork version: 0.2.7
```